### PR TITLE
Don't rely on hardcoded default project name

### DIFF
--- a/controller/authz/handler_base.go
+++ b/controller/authz/handler_base.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	typescorev1 "github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/types/config"
@@ -56,6 +57,7 @@ func Register(workload *config.ClusterContext) {
 		rbLister:      workload.RBAC.RoleBindings("").Controller().Lister(),
 		crbLister:     workload.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		crLister:      workload.RBAC.ClusterRoles("").Controller().Lister(),
+		nsLister:      workload.Core.Namespaces("").Controller().Lister(),
 		clusterLister: workload.Management.Management.Clusters("").Controller().Lister(),
 		clusterName:   workload.ClusterName,
 	}
@@ -75,6 +77,7 @@ type manager struct {
 	crLister      typesrbacv1.ClusterRoleLister
 	crbLister     typesrbacv1.ClusterRoleBindingLister
 	rbLister      typesrbacv1.RoleBindingLister
+	nsLister      typescorev1.NamespaceLister
 	clusterLister v3.ClusterLister
 	clusterName   string
 }

--- a/controller/authz/project_handler.go
+++ b/controller/authz/project_handler.go
@@ -3,10 +3,12 @@ package authz
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func newProjectLifecycle(r *manager) *pLifecycle {
@@ -31,7 +33,9 @@ func (p *pLifecycle) Create(project *v3.Project) (*v3.Project, error) {
 		}
 
 	}
-	return project, nil
+
+	err := p.ensureDefaultNamespaceAssigned(project)
+	return project, err
 }
 
 func (p *pLifecycle) Updated(project *v3.Project) (*v3.Project, error) {
@@ -74,4 +78,51 @@ func (p *pLifecycle) Remove(project *v3.Project) (*v3.Project, error) {
 	}
 
 	return nil, nil
+}
+
+func (p *pLifecycle) ensureDefaultNamespaceAssigned(project *v3.Project) error {
+	if _, ok := project.Labels["authz.management.cattle.io/default-project"]; !ok {
+		return nil
+	}
+	ns, err := p.m.nsLister.Get("", "default")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	cluster, err := p.m.clusterLister.Get("", p.m.clusterName)
+	if err != nil {
+		return err
+	}
+	if cluster == nil {
+		return errors.Errorf("couldn't find cluster %v", p.m.clusterName)
+	}
+
+	updateCluster := false
+	c, err := v3.ClusterConditionDefaultNamespaceAssigned.DoUntilTrue(cluster.DeepCopy(), func() (runtime.Object, error) {
+		updateCluster = true
+		projectID := ns.Annotations[projectIDAnnotation]
+		if projectID != "" {
+			return nil, nil
+		}
+
+		ns = ns.DeepCopy()
+		if ns.Annotations == nil {
+			ns.Annotations = map[string]string{}
+		}
+		ns.Annotations[projectIDAnnotation] = fmt.Sprintf("%v:%v", p.m.clusterName, project.Name)
+		if _, err := p.m.workload.Core.Namespaces(p.m.clusterName).Update(ns); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	})
+	if updateCluster {
+		if _, err := p.m.workload.Management.Management.Clusters("").ObjectClient().Update(cluster.Name, c); err != nil {
+			return err
+		}
+	}
+	return err
 }


### PR DESCRIPTION
When assigning the default namespace to a project
addresses https://github.com/rancher/rancher/issues/10999